### PR TITLE
BREAKING CHANGE: move meta data to out of band

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ serde_json = "1.0.83"
 http = "0.2.8"
 http-serde = "1.1.0"
 scru128 = { version = "2.2.0", features = ["serde"] }
+command-fds = { version = "0.2.2", features = ["tokio"] }
+tokio-pipe = "0.2.12"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,7 +181,7 @@ async fn handler(
         res_reader.read_to_string(&mut buf).await.unwrap();
         println!("buf: {}", buf);
 
-        let mut res_meta = if buf.len() > 0 {
+        let mut res_meta = if !buf.is_empty() {
             serde_json::from_str::<Response>(&buf).unwrap()
         } else {
             Response::default()

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,10 +180,10 @@ async fn handler(
         let mut buf = String::new();
         res_reader.read_to_string(&mut buf).await.unwrap();
 
-        let mut res_meta = if !buf.is_empty() {
-            serde_json::from_str::<Response>(&buf).unwrap()
-        } else {
+        let mut res_meta = if buf.is_empty() {
             Response::default()
+        } else {
+            serde_json::from_str::<Response>(&buf).unwrap()
         };
 
         let status = res_meta.status.unwrap_or(200);
@@ -213,7 +213,6 @@ async fn handler(
             }
         }
 
-        // todo: this should not return until the body stream has ended
         let stdout = p.stdout.take().expect("failed to take stdout");
         let stdout = tokio::io::BufReader::new(stdout);
         let stdout = tokio_util::io::ReaderStream::new(stdout);

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,7 +179,6 @@ async fn handler(
     let read_stdout = async {
         let mut buf = String::new();
         res_reader.read_to_string(&mut buf).await.unwrap();
-        println!("buf: {}", buf);
 
         let mut res_meta = if !buf.is_empty() {
             serde_json::from_str::<Response>(&buf).unwrap()


### PR DESCRIPTION
The Request metadata is now sent to the child process via fd 3 and the Response meta data is now read from fd 4.

This allows the `stdin` and `stdout` out of the child process to be used exclusively for the Request and Response body.

Pretty sure this PR also fixes: #12 
