### PR TITLE
feat: add a normalized authority to the request meta-data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,13 @@ name = "http-sh"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+name = "http_sh"
+path = "src/lib.rs"
+
+[[bin]]
+name = "http-sh"
+
 [dependencies]
 clap = { version = "4.1.4", features = ["derive", "wrap_help"] }
 tokio = { version = "1", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Request {
+    pub stamp: scru128::Scru128Id,
+    pub message: String,
+    #[serde(with = "http_serde::method")]
+    pub method: http::method::Method,
+    pub proto: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_ip: Option<std::net::IpAddr>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub remote_port: Option<u16>,
+    #[serde(with = "http_serde::header_map")]
+    pub headers: http::header::HeaderMap,
+    #[serde(with = "http_serde::uri")]
+    pub uri: http::Uri,
+    pub path: String,
+    pub query: HashMap<String, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response: Option<Response>,
+}
+
+#[derive(Default, Debug, Serialize, Deserialize, Clone)]
+pub struct Response {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub headers: Option<std::collections::HashMap<String, String>>,
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,11 @@ use serde::{Deserialize, Serialize};
 pub struct Request {
     pub stamp: scru128::Scru128Id,
     pub message: String,
+    pub proto: String,
     #[serde(with = "http_serde::method")]
     pub method: http::method::Method,
-    pub proto: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authority: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub remote_ip: Option<std::net::IpAddr>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,16 @@ async fn handler(
     drop(res_writer);
 
     let (req_parts, req_body) = req.into_parts();
+
+    let uri = req_parts.uri.clone().into_parts();
+
+    let authority: Option<String> = uri.authority.as_ref().map(|a| a.to_string()).or_else(|| {
+        req_parts
+            .headers
+            .get("host")
+            .map(|a| a.to_str().unwrap().to_owned())
+    });
+
     let path = req_parts.uri.path().to_string();
     let query: HashMap<String, String> = req_parts
         .uri
@@ -191,9 +201,10 @@ async fn handler(
         stamp: scru128::new(),
         message: "request".to_string(),
         proto: format!("{:?}", req_parts.version),
+        method: req_parts.method,
+        authority,
         remote_ip: addr.as_ref().map(|a| a.ip()),
         remote_port: addr.as_ref().map(|a| a.port()),
-        method: req_parts.method,
         headers: req_parts.headers,
         uri: req_parts.uri,
         path,


### PR DESCRIPTION
- pull Request / Response into a lib so they can be used by tests/
- add a normalized authority to the request meta data
